### PR TITLE
fix(ever-carrier): fixed wrong displayed distance

### DIFF
--- a/carrier/mobile-ionic/src/pages/main/delivery/delivery.ts
+++ b/carrier/mobile-ionic/src/pages/main/delivery/delivery.ts
@@ -108,16 +108,17 @@ export class DeliveryPage implements AfterViewInit {
 			}
 		} as IGeoLocation;
 
-		this.carrierUserDistance = Utils.getDistance(
-			order.warehouse['geoLocation'],
-			dbGeoInput as GeoLocation
-		).toFixed(2);
-
 		const origin = new google.maps.LatLng(
 			position.coords.latitude,
 			position.coords.longitude
 		);
 		const userGeo = order.user['geoLocation'];
+
+		this.carrierUserDistance = Utils.getDistance(
+			userGeo,
+			dbGeoInput as GeoLocation
+		).toFixed(2);
+
 		const destination = new google.maps.LatLng(
 			userGeo.loc.coordinates[1],
 			userGeo.loc.coordinates[0]

--- a/carrier/mobile-ionic/src/pages/main/drive-to-warehouse/drive-to-warehouse.ts
+++ b/carrier/mobile-ionic/src/pages/main/drive-to-warehouse/drive-to-warehouse.ts
@@ -79,10 +79,6 @@ export class DriveToWarehousePage {
 							this.workTaken =
 								order.carrierStatus !==
 								OrderCarrierStatus.NoCarrier;
-							this.carrierUserDistance = Utils.getDistance(
-								order.user.geoLocation,
-								dbGeoInput as GeoLocation
-							).toFixed(2);
 
 							const origin = new google.maps.LatLng(
 								position.coords.latitude,
@@ -90,6 +86,12 @@ export class DriveToWarehousePage {
 							);
 
 							const merchantGeo = order.warehouse['geoLocation'];
+
+							this.carrierUserDistance = Utils.getDistance(
+								merchantGeo,
+								dbGeoInput as GeoLocation
+							).toFixed(2);
+
 							const destination = new google.maps.LatLng(
 								merchantGeo.loc.coordinates[1],
 								merchantGeo.loc.coordinates[0]

--- a/carrier/mobile-ionic/src/pages/main/starting-delivery/starting-delivery.ts
+++ b/carrier/mobile-ionic/src/pages/main/starting-delivery/starting-delivery.ts
@@ -86,17 +86,18 @@ export class StartingDeliveryPage implements AfterViewInit {
 			}
 		} as IGeoLocation;
 
-		this.carrierUserDistance = Utils.getDistance(
-			this.selectedOrder.warehouse['geoLocation'],
-			dbGeoInput as GeoLocation
-		).toFixed(2);
-
 		const origin = new google.maps.LatLng(
 			position.coords.latitude,
 			position.coords.longitude
 		);
 
 		const userGeo = this.selectedOrder.user['geoLocation'];
+
+		this.carrierUserDistance = Utils.getDistance(
+			userGeo as GeoLocation,
+			dbGeoInput as GeoLocation
+		).toFixed(2);
+
 		const destination = new google.maps.LatLng(
 			userGeo.loc.coordinates[1],
 			userGeo.loc.coordinates[0]


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
Fixed wrong distance number below the map. Now it works like follow: When the carrier starts driving to the warehouse is shows the distance between carrier and warehouse, and when the carrier starts delivering is shown the distance between carrier and user. Before it was the opposite.