### PR TITLE
Added missing ',' causing admin compilation failures

### DIFF
--- a/admin/website-angular/scripts/configure.ts
+++ b/admin/website-angular/scripts/configure.ts
@@ -57,7 +57,7 @@ export const environment: Environment = {
 
   CURRENCY_SYMBOL: '${env.CURRENCY_SYMBOL}',
 
-  DEFAULT_LANGUAGE: '${env.DEFAULT_LANGUAGE}'
+  DEFAULT_LANGUAGE: '${env.DEFAULT_LANGUAGE}',
 
   // For maintenance micro service. Ever maintanance API URL: https://maintenance.ever.co/status
   SETTINGS_APP_TYPE: '${env.SETTINGS_APP_TYPE}',


### PR DESCRIPTION
-   [ X ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [ X ] Have you explained what your changes do, and why they add value?

Missing , in config generation causing admin compilation failures
 