### PR TITLE
fix: made closing button not visible on create customer panel

### DIFF
--- a/packages/merchant-tablet-ionic/src/@shared/user/mutation/user-mutation.component.html
+++ b/packages/merchant-tablet-ionic/src/@shared/user/mutation/user-mutation.component.html
@@ -5,7 +5,7 @@
 			(user ? 'Edit customer' : 'CUSTOMERS_VIEW.ADD_CUSTOMER') | translate
 		}}
 	</h4>
-	<button class="close" (click)="cancelModal()">
+	<button class="close" *ngIf="visible" (click)="cancelModal()">
 		<i class="fa fa-close"></i>
 	</button>
 	<ion-row class="crete-user">

--- a/packages/merchant-tablet-ionic/src/@shared/user/mutation/user-mutation.component.ts
+++ b/packages/merchant-tablet-ionic/src/@shared/user/mutation/user-mutation.component.ts
@@ -43,6 +43,12 @@ export class UserMutationComponent {
 	@Output()
 	customerIdEmitter = new EventEmitter<string>();
 
+	@Input()
+	visible: boolean = true;
+
+	@Output()
+	updateVisible = new EventEmitter<boolean>();
+
 	mapCoordinatesEmitter = new EventEmitter<
 		google.maps.LatLng | google.maps.LatLngLiteral
 	>();
@@ -77,6 +83,11 @@ export class UserMutationComponent {
 
 	broadcastCustomerId(customerId: string) {
 		this.customerIdEmitter.emit(customerId);
+	}
+
+	changeState(): void {
+		this.visible = false;
+		this.updateVisible.emit(this.visible);
 	}
 
 	async createCustomer() {

--- a/packages/merchant-tablet-ionic/src/components/order/select-add-customer.component.ts
+++ b/packages/merchant-tablet-ionic/src/components/order/select-add-customer.component.ts
@@ -24,6 +24,8 @@ import { TranslateService } from '@ngx-translate/core';
 
 			<div *ngIf="!isSelectedFromExisting">
 				<user-mutation
+					[visible]="visible"
+					(changeState)="changeState($event)"
 					(customerIdEmitter)="broadcastCustomerId($event)"
 				></user-mutation>
 			</div>
@@ -32,6 +34,8 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class SelectAddCustomerComponent implements OnInit {
 	private ngDestroy$ = new Subject<void>();
+
+	visible: boolean;
 
 	@Input()
 	customerOptionSelected: number;
@@ -61,6 +65,10 @@ export class SelectAddCustomerComponent implements OnInit {
 
 	selectFromExisting(ev) {
 		this.broadcastCustomerId(ev.data.id);
+	}
+
+	changeState(ev): void {
+		this.visible = ev;
 	}
 
 	broadcastCustomerId(customerId: string) {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
I took another approach which was to hide the closing button as we already have routes on warehouse page form which user can shoose. Another problem was that the used mutation component is a modal and when we are on customers page and try to create new customer the modal and the coresponding close button works fine. When we are on warehouse page trying to create customer the closing button doesn't corespong with the same mutation component.
![ONiN3nRLCc](https://user-images.githubusercontent.com/28997304/80572009-3ca36700-8a06-11ea-9b48-f6a7d213c54a.gif)
