### PR TITLE
fix: create order ionicons were not visible

### DIFF
--- a/packages/merchant-tablet-ionic/angular.json
+++ b/packages/merchant-tablet-ionic/angular.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../node_modules/@angular/cli/lib/config/schema.json",
+	"$schema": "./node_modules/@angular/cli/lib/config/schema.json",
 	"version": 1,
 	"defaultProject": "app",
 	"newProjectRoot": "projects",
@@ -32,6 +32,11 @@
 							{
 								"glob": "**/*.svg",
 								"input": "../../node_modules/ionicons/dist/ionicons/svg",
+								"output": "./svg"
+							},
+							{
+								"glob": "**/*.svg",
+								"input": "../../node_modules/@ionic/core/dist/ionic/svg",
 								"output": "./svg"
 							},
 							"src/manifest.json"


### PR DESCRIPTION
-   [ ] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [ ] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
User another approach with this problem by adding a second path in angular.json file to svg icons on different node_modules folder which solved the problem without the need to refactor all icons which was my first attempt!
https://www.loom.com/share/933b56ff32924488a06cd901d2ae385e