### PR TITLE
fix: manage store empty input fields after save

### DIFF
--- a/packages/admin-web-angular/src/app/pages/+warehouses/+warehouse/+warehouse-manage/warehouse-manage.component.ts
+++ b/packages/admin-web-angular/src/app/pages/+warehouses/+warehouse/+warehouse-manage/warehouse-manage.component.ts
@@ -78,6 +78,7 @@ export class WarehouseManageComponent implements OnInit {
 				paymentGateways: tabsInfoRaw.paymentsGateways,
 			};
 
+			const username = this.tabsForm.value.account['username'];
 			const passwordOld = tabsInfoRaw.password.current;
 			const passwordNew = tabsInfoRaw.password.new;
 
@@ -100,6 +101,14 @@ export class WarehouseManageComponent implements OnInit {
 			this._showWarehouseUpdateSuccessMessage(warehouse);
 
 			this.warehouseManageTabs.warehouseUpdateFinish();
+			this.warehouseManageTabs.accountComponent.form.setValue({
+				username: username,
+				password: {
+					confirm: '',
+					current: '',
+					new: '',
+				},
+			});
 		} catch (err) {
 			this.loading = false;
 			this.toasterService.pop(


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
Input fields are now reset after Save when changing account settings in Stores -> Store -> Manage Store -> Account.

https://www.loom.com/share/a915842018ed4bf08e50a0bde87f0473