### PR TITLE
fix: fixing save button on admin/profile-basic-info

### DIFF
--- a/packages/admin-web-angular/src/app/pages/+profile/edit/basic-info/basic-info.component.ts
+++ b/packages/admin-web-angular/src/app/pages/+profile/edit/basic-info/basic-info.component.ts
@@ -102,6 +102,7 @@ export class BasicInfoComponent implements OnChanges, OnDestroy {
 				.pipe(first())
 				.toPromise();
 			this.loading = false;
+			this.basicInfoForm.markAsPristine();
 			this.toasterService.pop('success', 'Successfully updated data');
 		} catch (error) {
 			this.loading = false;
@@ -137,6 +138,7 @@ export class BasicInfoComponent implements OnChanges, OnDestroy {
 		this.validations.emailControl();
 		this.validations.firstNameControl();
 		this.validations.lastNameControl();
+		this.validations.pictureControl();
 	}
 
 	deleteImg() {
@@ -192,6 +194,15 @@ export class BasicInfoComponent implements OnChanges, OnDestroy {
 							? this.nameMustContainOnlyLetters()
 							: Object.keys(this.lastName.errors)[0]
 						: '';
+				});
+		},
+		pictureControl: () => {
+			this.picture.valueChanges
+				.pipe(debounceTime(500), takeUntil(this.ngDestroy$))
+				.subscribe((value) => {
+					value !== this.admin.pictureUrl && !this.picture.invalid
+						? this.picture.markAsDirty()
+						: this.picture.markAsPristine();
 				});
 		},
 	};


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
---
issue #1127 
1. "markAsPristine()" is added in saveChanges() function to set the save button disabled again when clicking it.  
2. Because uploading image URL field is a shared component and I don't want to set formControlName property to it, so I forced markAsDirty() when the new value is not equal to the saved value (in valueChanges-subscribe)

https://www.loom.com/share/a5805fc7561b4f99aca8c90dd10ea1e9