### PR TITLE
feat: optionally disable customer's order cancelation

### DIFF
--- a/packages/admin-web-angular/src/app/@shared/warehouse/forms/basic-info/basic-info-form.component.ts
+++ b/packages/admin-web-angular/src/app/@shared/warehouse/forms/basic-info/basic-info-form.component.ts
@@ -27,6 +27,7 @@ export type WarehouseBasicInfo = Pick<
 	| 'useOnlyRestrictedCarriersForDelivery'
 	| 'preferRestrictedCarriersForDelivery'
 	| 'ordersShortProcess'
+	| 'orderCancelation'
 >;
 
 @Component({
@@ -138,6 +139,7 @@ export class BasicInfoFormComponent implements OnInit {
 						preferRestrictedCarriersForDelivery: false,
 				  }),
 			ordersShortProcess: basicInfo.ordersShortProcess,
+			orderCancelation: { enabled: false, onState: 0 },
 		};
 	}
 

--- a/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.html
+++ b/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.html
@@ -143,6 +143,37 @@
 		</div>
 
 		<div class="form-group row">
+			<div class="col-sm-4 offset-sm-2">
+				<div class="checkbox">
+					<nb-checkbox
+						status="success"
+						formControlName="enabledOrderCancelation"
+						>{{
+							'WAREHOUSE_VIEW.MUTATION.UNALLOWED_ORDER_CANCELATION'
+								| translate
+						}}</nb-checkbox
+					>
+				</div>
+			</div>
+			<div class="col-sm-4" *ngIf="enabledOrderCancelation.value">
+				<select
+					class="form-control"
+					formControlName="stateOrderCancelation"
+				>
+					<option
+						*ngFor="let option of orderCancelationOptions"
+						value="{{ option.value }}"
+					>
+						{{
+							'WAREHOUSE_VIEW.MUTATION.ORDER_CANCELATION_OPTIONS.' +
+								option.text | translate
+						}}
+					</option>
+				</select>
+			</div>
+		</div>
+
+		<div class="form-group row">
 			<label class="col-sm-2 control-label">{{
 				'WAREHOUSE_VIEW.MUTATION.CARRIERS' | translate
 			}}</label>

--- a/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.ts
+++ b/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.ts
@@ -33,6 +33,7 @@ export type WarehouseManageTabsDetails = Pick<
 	| 'useOnlyRestrictedCarriersForDelivery'
 	| 'preferRestrictedCarriersForDelivery'
 	| 'ordersShortProcess'
+	| 'orderCancelation'
 >;
 
 @Component({
@@ -56,6 +57,20 @@ export class WarehouseManageTabsDetailsComponent
 	carriersOptions: IMultiSelectOption[];
 
 	private _delivery: 'all' | 'onlyStore' | 'preferStore' = 'all';
+
+	// orderCancelationOptions can be moved to a separate file
+	orderCancelationOptions = [
+		{ text: 'ORDERING', value: 1 },
+		{ text: 'START_PROCESSING', value: 2 },
+		{ text: 'START_ALLOCATION', value: 3 },
+		{ text: 'ALLOCATED', value: 4 },
+		{ text: 'START_PACKAGING', value: 5 },
+		{ text: 'PACKAGED', value: 6 },
+		{ text: 'CARRIER_TAKE_WORK', value: 7 },
+		{ text: 'CARRIER_GOT_IT', value: 8 },
+		{ text: 'CARRIER_START_DELIVERY', value: 9 },
+		{ text: 'DELIVERED', value: 11 },
+	];
 
 	constructor(
 		private readonly _carrierRouter: CarrierRouter,
@@ -103,6 +118,10 @@ export class WarehouseManageTabsDetailsComponent
 	}
 	get ordersShortProcess() {
 		return this.form.get('ordersShortProcess');
+	}
+
+	get enabledOrderCancelation() {
+		return this.form.get('enabledOrderCancelation');
 	}
 
 	get delivery() {
@@ -157,6 +176,9 @@ export class WarehouseManageTabsDetailsComponent
 			preferRestrictedCarriersForDelivery: [false],
 			carriersIds: [[]],
 			ordersShortProcess: [false],
+
+			enabledOrderCancelation: [false],
+			stateOrderCancelation: [0],
 		});
 	}
 
@@ -181,6 +203,9 @@ export class WarehouseManageTabsDetailsComponent
 			useOnlyRestrictedCarriersForDelivery: boolean;
 			preferRestrictedCarriersForDelivery: boolean;
 			ordersShortProcess: boolean;
+
+			enabledOrderCancelation: boolean;
+			stateOrderCancelation: number;
 		};
 
 		return {
@@ -209,6 +234,10 @@ export class WarehouseManageTabsDetailsComponent
 						useOnlyRestrictedCarriersForDelivery: false,
 						preferRestrictedCarriersForDelivery: false,
 				  }),
+			orderCancelation: {
+				enabled: basicInfo.enabledOrderCancelation,
+				onState: Number(basicInfo.stateOrderCancelation),
+			},
 		};
 	}
 
@@ -220,17 +249,30 @@ export class WarehouseManageTabsDetailsComponent
 				useOnlyRestrictedCarriersForDelivery: false,
 				preferRestrictedCarriersForDelivery: false,
 				ordersShortProcess: false,
+				enabledOrderCancelation: basicInfo.orderCancelation
+					? basicInfo.orderCancelation.enabled
+					: false,
+				stateOrderCancelation: basicInfo.orderCancelation
+					? basicInfo.orderCancelation.onState
+					: 0,
 			},
 			basicInfo
 		);
 
+		//Remove orderCancelation from the list becouse its  not actually form control
+		//can be improved
+		const filteredValues = Object.keys(this.getValue());
+		_.remove(filteredValues, (e) => e === 'orderCancelation');
+
 		this.form.setValue(
 			_.pick(basicInfo, [
-				...Object.keys(this.getValue()),
+				...filteredValues,
 				'hasRestrictedCarriers',
 				'carriersIds',
 				'useOnlyRestrictedCarriersForDelivery',
 				'preferRestrictedCarriersForDelivery',
+				'enabledOrderCancelation',
+				'stateOrderCancelation',
 			])
 		);
 

--- a/packages/admin-web-angular/src/assets/i18n/en-US.json
+++ b/packages/admin-web-angular/src/assets/i18n/en-US.json
@@ -461,6 +461,19 @@
 			"ADD": "Add",
 			"EDIT": "Edit",
 			"ZONE_NAME": "Zone name",
+			"UNALLOWED_ORDER_CANCELATION": "Unallowed Order Cancelation",
+			"ORDER_CANCELATION_OPTIONS": {
+				"ORDERING": "After Ordering",
+				"START_PROCESSING": "After Start Processing",
+				"START_ALLOCATION": "After Start Allocation",
+				"ALLOCATED": "After Allocated",
+				"START_PACKAGING": "After Start Packaging",
+				"PACKAGED": "After Packaged",
+				"CARRIER_TAKE_WORK": "After Carrier Take Work",
+				"CARRIER_GOT_IT": "After Carrier Got It",
+				"CARRIER_START_DELIVERY": "After Carrier Start Delivery",
+				"DELIVERED": "After Delivered"
+			},
 			"ERRORS": {
 				"NAME_IS_REQUIRED": "Warehouse name is required",
 				"NAME_ATLEAST_3_CHARS": "Name must be at least 3 characters long",
@@ -566,7 +579,7 @@
 			"AVAILABILITY": "Availability",
 			"TYPE": "Type",
 			"DELIVERY": "Delivery",
-			"TAKEAWAY": "Takeaway"			
+			"TAKEAWAY": "Takeaway"
 		},
 		"NEW_PRODUCT_TYPE": "New Type Product",
 		"ADD_PRODUCTS": "Add Products",

--- a/packages/admin-web-angular/src/assets/i18n/en.json
+++ b/packages/admin-web-angular/src/assets/i18n/en.json
@@ -461,6 +461,19 @@
 			"ADD": "Add",
 			"EDIT": "Edit",
 			"ZONE_NAME": "Zone name",
+			"UNALLOWED_ORDER_CANCELATION": "Unallowed Order Cancelation",
+			"ORDER_CANCELATION_OPTIONS": {
+				"ORDERING": "After Ordering",
+				"START_PROCESSING": "After Start Processing",
+				"START_ALLOCATION": "After Start Allocation",
+				"ALLOCATED": "After Allocated",
+				"START_PACKAGING": "After Start Packaging",
+				"PACKAGED": "After Packaged",
+				"CARRIER_TAKE_WORK": "After Carrier Take Work",
+				"CARRIER_GOT_IT": "After Carrier Got It",
+				"CARRIER_START_DELIVERY": "After Carrier Start Delivery",
+				"DELIVERED": "After Delivered"
+			},
 			"ERRORS": {
 				"NAME_IS_REQUIRED": "Warehouse name is required",
 				"NAME_ATLEAST_3_CHARS": "Name must be at least 3 characters long",
@@ -566,7 +579,7 @@
 			"AVAILABILITY": "Availability",
 			"TYPE": "Type",
 			"DELIVERY": "Delivery",
-			"TAKEAWAY": "Takeaway"			
+			"TAKEAWAY": "Takeaway"
 		},
 		"NEW_PRODUCT_TYPE": "New Type Product",
 		"ADD_PRODUCTS": "Add Products",

--- a/packages/common/src/entities/Warehouse.ts
+++ b/packages/common/src/entities/Warehouse.ts
@@ -342,6 +342,15 @@ class Warehouse extends DBObject<IWarehouse, IWarehouseCreateObject>
 	@Schema({ type: Boolean, required: false })
 	@Column()
 	ordersShortProcess?: boolean;
+
+	/**
+	 *
+	 *
+	 * @type { {enabled: Boolean, onState: Number} }
+	 * @memberof Warehouse
+	 */
+	@Schema({ type: { enabled: Boolean, onState: Number }, required: false })
+	orderCancelation?: { enabled: boolean; onState: number };
 }
 
 export type WithFullProducts = Warehouse & {

--- a/packages/common/src/interfaces/IWarehouse.ts
+++ b/packages/common/src/interfaces/IWarehouse.ts
@@ -135,6 +135,7 @@ export interface IWarehouseCreateObject extends DBCreateObject {
 	useOnlyRestrictedCarriersForDelivery?: boolean;
 	preferRestrictedCarriersForDelivery?: boolean;
 	ordersShortProcess?: boolean;
+	orderCancelation?: { enabled: boolean; onState: number };
 }
 
 interface IWarehouse extends IWarehouseCreateObject, DBRawObject {
@@ -152,6 +153,7 @@ interface IWarehouse extends IWarehouseCreateObject, DBRawObject {
 	useOnlyRestrictedCarriersForDelivery?: boolean;
 	preferRestrictedCarriersForDelivery?: boolean;
 	ordersShortProcess?: boolean;
+	orderCancelation?: { enabled: boolean; onState: number };
 }
 
 export default IWarehouse;

--- a/packages/core/src/graphql/warehouses/warehouses.types.graphql
+++ b/packages/core/src/graphql/warehouses/warehouses.types.graphql
@@ -47,6 +47,7 @@ type Warehouse {
 	useOnlyRestrictedCarriersForDelivery: Boolean
 	preferRestrictedCarriersForDelivery: Boolean
 	ordersShortProcess: Boolean
+	orderCancelation: OrderCancelation!
 }
 
 input WarehouseCreateInput {
@@ -206,4 +207,9 @@ input GeoLocationCreateObject {
 	postcode: String!
 	streetAddress: String!
 	house: String!
+}
+
+type OrderCancelation {
+	enabled: Boolean
+	onState: Int
 }

--- a/packages/merchant-tablet-ionic/src/services/warehouses.service.ts
+++ b/packages/merchant-tablet-ionic/src/services/warehouses.service.ts
@@ -230,6 +230,10 @@ export class WarehousesService {
 							contactEmail
 							contactPhone
 							ordersShortProcess
+							orderCancelation {
+								enabled
+								onState
+							}
 							geoLocation {
 								city
 								streetAddress

--- a/packages/shop-web-angular/src/app/+orders/order/order.component.html
+++ b/packages/shop-web-angular/src/app/+orders/order/order.component.html
@@ -63,6 +63,7 @@
 			mat-raised-button
 			color="accent"
 			class="cancel-button"
+			[disabled]="_isButtonDisabled"
 		>
 			<svg viewBox="0 0 24 24">
 				<path


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
https://github.com/ever-co/feature-requests/issues/56
in the options dropdown list - "Ordering" is replaced with "After Ordering" - after recording the video 
 
The feat is added only in /shopweb

* after every orders state changing - the 'cancel' button is disabled until the new data is received
https://www.loom.com/share/73bbd42e7aad42c7b84d1475190ca8d0


