### PR TITLE
fix: filter takeaway orders from carriers order list

### DIFF
--- a/packages/core/src/services/geo-locations/GeoLocationsOrdersService.ts
+++ b/packages/core/src/services/geo-locations/GeoLocationsOrdersService.ts
@@ -215,7 +215,10 @@ export class GeoLocationsOrdersService
 			.limit(options.limit || 1)
 			.exec();
 
-		return orders.filter((o) => o !== null).map((o) => new Order(o));
+		return orders
+			.filter((o) => o !== null)
+			.filter((o) => o.orderType === 0)
+			.map((o) => new Order(o));
 	}
 
 	/**


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
issue: https://github.com/ever-co/ever/issues/1188

I think the problem was that every order (doesn't matter takeaway or delivery) is displayed on the carrier device because orderType property is additionally added and nowhere filtered (not sure)

I just added a filter on orders which the carrier receives (on server-side)
Now the carrier can get only orders with orderType equal to "delivery"(0)

https://www.loom.com/share/95c5933f8d9b4c768f42fedeaf321aad