### PR TITLE
Feat/#1271 carrier order competition

### DIFF
--- a/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.html
+++ b/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.html
@@ -185,6 +185,22 @@
 		</div>
 
 		<div class="form-group row">
+			<div class="col-sm-9 offset-sm-2">
+				<div class="checkbox">
+					<nb-checkbox
+						status="success"
+						formControlName="carrierCompetition"
+					>
+						{{
+							'WAREHOUSE_VIEW.MUTATION.CARRIER_WORK_COMPETITION'
+								| translate
+						}}
+					</nb-checkbox>
+				</div>
+			</div>
+		</div>
+
+		<div class="form-group row">
 			<label class="col-sm-2 control-label">{{
 				'WAREHOUSE_VIEW.MUTATION.CARRIERS' | translate
 			}}</label>

--- a/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.ts
+++ b/packages/admin-web-angular/src/app/@shared/warehouse/forms/warehouse-manage-tabs/details/warehouse-manage-tabs-details.component.ts
@@ -35,6 +35,7 @@ export type WarehouseManageTabsDetails = Pick<
 	| 'ordersShortProcess'
 	| 'orderCancelation'
 	| 'inStoreMode'
+	| 'carrierCompetition'
 >;
 
 @Component({
@@ -182,6 +183,7 @@ export class WarehouseManageTabsDetailsComponent
 			carriersIds: [[]],
 			ordersShortProcess: [false],
 			inStoreMode: [],
+			carrierCompetition: [false],
 
 			enabledOrderCancelation: [false],
 			stateOrderCancelation: [0],
@@ -210,6 +212,7 @@ export class WarehouseManageTabsDetailsComponent
 			preferRestrictedCarriersForDelivery: boolean;
 			ordersShortProcess: boolean;
 			inStoreMode: boolean;
+			carrierCompetition: boolean;
 
 			enabledOrderCancelation: boolean;
 			stateOrderCancelation: number;
@@ -219,6 +222,7 @@ export class WarehouseManageTabsDetailsComponent
 			ordersShortProcess: basicInfo.ordersShortProcess,
 			isActive: basicInfo.isActive,
 			inStoreMode: basicInfo.inStoreMode,
+			carrierCompetition: basicInfo.carrierCompetition,
 			isManufacturing: basicInfo.isManufacturing,
 			isCarrierRequired: basicInfo.isCarrierRequired,
 			name: basicInfo.name,
@@ -257,6 +261,7 @@ export class WarehouseManageTabsDetailsComponent
 				useOnlyRestrictedCarriersForDelivery: false,
 				preferRestrictedCarriersForDelivery: false,
 				ordersShortProcess: false,
+				carrierCompetition: false,
 				enabledOrderCancelation: basicInfo.orderCancelation
 					? basicInfo.orderCancelation.enabled
 					: false,

--- a/packages/admin-web-angular/src/assets/i18n/en-US.json
+++ b/packages/admin-web-angular/src/assets/i18n/en-US.json
@@ -463,6 +463,7 @@
 			"ZONE_NAME": "Zone name",
 			"UNALLOWED_ORDER_CANCELATION": "Unallowed Order Cancelation",
 			"IN_STORE_MODE": "In-store mode",
+			"CARRIER_WORK_COMPETITION": "Carrier Work Competition",
 			"ORDER_CANCELATION_OPTIONS": {
 				"ORDERING": "After Ordering",
 				"START_PROCESSING": "After Start Processing",

--- a/packages/common/src/entities/Warehouse.ts
+++ b/packages/common/src/entities/Warehouse.ts
@@ -362,6 +362,17 @@ class Warehouse extends DBObject<IWarehouse, IWarehouseCreateObject>
 	 */
 	@Schema({ type: { enabled: Boolean, onState: Number }, required: false })
 	orderCancelation?: { enabled: boolean; onState: number };
+
+	/**
+	 * Enable or disable carrier works competition mode
+	 *
+	 * @type {boolean}
+	 * @memberof Warehouse
+	 */
+
+	@Types.Boolean(false)
+	@Column()
+	carrierCompetition?: boolean;
 }
 
 export type WithFullProducts = Warehouse & {

--- a/packages/common/src/interfaces/IWarehouse.ts
+++ b/packages/common/src/interfaces/IWarehouse.ts
@@ -144,6 +144,7 @@ export interface IWarehouseCreateObject extends DBCreateObject {
 	preferRestrictedCarriersForDelivery?: boolean;
 	ordersShortProcess?: boolean;
 	orderCancelation?: { enabled: boolean; onState: number };
+	carrierCompetition?: boolean;
 }
 
 interface IWarehouse extends IWarehouseCreateObject, DBRawObject {
@@ -163,6 +164,7 @@ interface IWarehouse extends IWarehouseCreateObject, DBRawObject {
 	ordersShortProcess?: boolean;
 	orderCancelation?: { enabled: boolean; onState: number };
 	inStoreMode?: boolean;
+	carrierCompetition?: boolean;
 }
 
 export default IWarehouse;

--- a/packages/core/src/graphql/warehouses/warehouses.types.graphql
+++ b/packages/core/src/graphql/warehouses/warehouses.types.graphql
@@ -49,6 +49,7 @@ type Warehouse {
 	ordersShortProcess: Boolean
 	orderCancelation: OrderCancelation!
 	inStoreMode: Boolean!
+	carrierCompetition: Boolean!
 }
 
 input WarehouseCreateInput {
@@ -84,6 +85,7 @@ input WarehouseCreateInput {
 	useOnlyRestrictedCarriersForDelivery: Boolean
 	preferRestrictedCarriersForDelivery: Boolean
 	inStoreMode: Boolean!
+	carrierCompetition: Boolean!
 }
 
 input WarehousesFindInput {
@@ -120,6 +122,7 @@ input WarehousesFindInput {
 	useOnlyRestrictedCarriersForDelivery: Boolean
 	preferRestrictedCarriersForDelivery: Boolean
 	inStoreMode: Boolean!
+	carrierCompetition: Boolean!
 }
 
 type Query {

--- a/packages/core/src/services/geo-locations/GeoLocationsOrdersService.ts
+++ b/packages/core/src/services/geo-locations/GeoLocationsOrdersService.ts
@@ -147,7 +147,20 @@ export class GeoLocationsOrdersService
 								},
 							},
 						},
-						{ $project: { carrierCompetitoin: 1 } },
+						{
+							$project: {
+								carrierCompetition: {
+									$cond: {
+										if: {
+											$eq: ['$carrierCompetition', true],
+										},
+										then:
+											OrderCarrierStatus.CarrierSelectedOrder,
+										else: OrderCarrierStatus.NoCarrier,
+									},
+								},
+							},
+						},
 					],
 					as: 'fromWH',
 				},
@@ -167,12 +180,7 @@ export class GeoLocationsOrdersService
 						$expr: {
 							$lte: [
 								'$carrierStatus',
-								{
-									$ifNull: [
-										'$fromWH.carrierCompetitoin',
-										OrderCarrierStatus.CarrierSelectedOrder,
-									],
-								},
+								'$fromWH.carrierCompetition',
 							],
 						},
 						_id: { $nin: skippedOrderIds },
@@ -240,7 +248,20 @@ export class GeoLocationsOrdersService
 								},
 							},
 						},
-						{ $project: { carrierCompetitoin: 1 } },
+						{
+							$project: {
+								carrierCompetition: {
+									$cond: {
+										if: {
+											$eq: ['$carrierCompetition', true],
+										},
+										then:
+											OrderCarrierStatus.CarrierSelectedOrder,
+										else: OrderCarrierStatus.NoCarrier,
+									},
+								},
+							},
+						},
 					],
 					as: 'fromWH',
 				},
@@ -260,12 +281,7 @@ export class GeoLocationsOrdersService
 						$expr: {
 							$lte: [
 								'$carrierStatus',
-								{
-									$ifNull: [
-										'$fromWH.carrierCompetitoin',
-										OrderCarrierStatus.CarrierSelectedOrder,
-									],
-								},
+								'$fromWH.carrierCompetition',
 							],
 						},
 						_id: {

--- a/packages/core/src/services/geo-locations/GeoLocationsOrdersService.ts
+++ b/packages/core/src/services/geo-locations/GeoLocationsOrdersService.ts
@@ -117,7 +117,7 @@ export class GeoLocationsOrdersService
 			{ fullProducts: false, activeOnly: true }
 		);
 
-		const merchantsIds = merchants.map((m) => m._id);
+		const merchantsIds = merchants.map((m) => m._id.toString());
 
 		let searchByRegex = [];
 
@@ -127,23 +127,61 @@ export class GeoLocationsOrdersService
 			});
 		}
 
-		return this.ordersService.Model.find(
-			_.assign(
-				{
-					warehouse: { $in: merchantsIds },
-					warehouseStatus: {
-						$eq: OrderWarehouseStatus.PackagingFinished,
+		const count = await this.ordersService.Model.aggregate([
+			{
+				$lookup: {
+					from: 'warehouses',
+					let: {
+						wh: '$warehouse',
 					},
-					carrierStatus: {
-						$lte: OrderCarrierStatus.CarrierSelectedOrder,
-					},
-					_id: { $nin: skippedOrderIds },
+					pipeline: [
+						{
+							$match: {
+								$expr: {
+									$eq: [
+										{
+											$toString: '$_id',
+										},
+										'$$wh',
+									],
+								},
+							},
+						},
+						{ $project: { carrierCompetitoin: 1 } },
+					],
+					as: 'fromWH',
 				},
-				...searchByRegex
-			)
-		)
-			.countDocuments()
-			.exec();
+			},
+			{
+				$unwind: {
+					path: '$fromWH',
+				},
+			},
+			{
+				$match: _.assign(
+					{
+						warehouse: { $in: merchantsIds },
+						warehouseStatus: {
+							$eq: OrderWarehouseStatus.PackagingFinished,
+						},
+						$expr: {
+							$lte: [
+								'$carrierStatus',
+								{
+									$ifNull: [
+										'$fromWH.carrierCompetitoin',
+										OrderCarrierStatus.CarrierSelectedOrder,
+									],
+								},
+							],
+						},
+						_id: { $nin: skippedOrderIds },
+					},
+					...searchByRegex
+				),
+			},
+		]);
+		return count.length;
 	}
 
 	@asyncListener()
@@ -184,14 +222,51 @@ export class GeoLocationsOrdersService
 
 		const orders = await this.ordersService.Model.aggregate([
 			{
+				$lookup: {
+					from: 'warehouses',
+					let: {
+						wh: '$warehouse',
+					},
+					pipeline: [
+						{
+							$match: {
+								$expr: {
+									$eq: [
+										{
+											$toString: '$_id',
+										},
+										'$$wh',
+									],
+								},
+							},
+						},
+						{ $project: { carrierCompetitoin: 1 } },
+					],
+					as: 'fromWH',
+				},
+			},
+			{
+				$unwind: {
+					path: '$fromWH',
+				},
+			},
+			{
 				$match: _.assign(
 					{
 						warehouse: { $in: merchantsIds },
 						warehouseStatus: {
 							$eq: OrderWarehouseStatus.PackagingFinished,
 						},
-						carrierStatus: {
-							$lte: OrderCarrierStatus.CarrierSelectedOrder,
+						$expr: {
+							$lte: [
+								'$carrierStatus',
+								{
+									$ifNull: [
+										'$fromWH.carrierCompetitoin',
+										OrderCarrierStatus.CarrierSelectedOrder,
+									],
+								},
+							],
 						},
 						_id: {
 							$nin: skippedOrderIds.map((id) => new ObjectId(id)),


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/ever/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
@evereq 
issue: #1271
https://www.loom.com/share/c067a720d51044c0b52b3106b84adaa1

This code is not responsible for what happens after the order is saved in local storage. It just filters orders depending on which status they are before to be saved in the locale storage.
That is why in the video I should clear the local storage/order.

Video's explanation:
1. There are 2 different opened carriers 
2. Create order and make it ready for carriers
3. The order is visible for both carriers /and saved in local storage /. Click "take work" with Carrier1
** I think one of the issues that when one of the carriers click "take work" the status of the order is changing and the view automatically updates in both carriers.
4. Carrier2:  Delete order ID from local storage, because the order is already saved inside. 
5. Refresh: the order in no more visible for Carrier2 // Because "Carrier Work Competition " setting is disabled
** Another issue is that language is changing sometimes unwanted 
6. Finish the order. Change "Carrier Work Competition" to enabled. Create another order
7. Repeat 3 and 4.
8. Refresh: the Order appearing again and go to local storage again. // Because "Carrier Work Competition " setting is enabled
9. Carrier1: Click "I'm there and Got it" (that send the order to the next state)
10. Check if the Order is visible again - It is not ... 

Also once the order is inside the local storage( "3" of the video explanation) It is possible to complete it no matter that another carrier already takes it or finishes it. This is again an issue that is not related to this code. I think it should be fixed by adding additional checks - In which state the order is at the moment of clicking the button "take work" .. per example