### PR TITLE
ci(verdaccio): route dev+stage build through internal Verdaccio VIP (not prod)

### DIFF
--- a/.deploy/admin-web-angular/Dockerfile
+++ b/.deploy/admin-web-angular/Dockerfile
@@ -68,6 +68,16 @@ COPY --chown=node:node .snyk ./.snyk
 COPY --chown=node:node packages/common/package.json ./packages/common/package.json
 COPY --chown=node:node packages/common-angular/package.json ./packages/common-angular/package.json
 
+# Prefer the internal Verdaccio cache when VERDACCIO_REGISTRY is set (anonymous, backward-compatible);
+# empty (e.g. a fork) falls back to public npm. Writes the registry to .npmrc + .yarnrc and best-effort
+# (non-fatal) rewrites yarn.lock resolved URLs so the frozen-lockfile install below stays consistent.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
+		echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
+	fi
+
 RUN yarn bootstrap && yarn cache clean
 
 FROM node:16-alpine3.14 AS development

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -94,6 +94,16 @@ COPY --chown=node:node packages/common/package.json ./packages/common/package.js
 COPY --chown=node:node .snyk ./.snyk
 COPY --chown=node:node packages/core/.snyk ./packages/core/.snyk
 
+# Prefer the internal Verdaccio cache when VERDACCIO_REGISTRY is set (anonymous, backward-compatible);
+# empty (e.g. a fork) falls back to public npm. Writes the registry to .npmrc + .yarnrc and best-effort
+# (non-fatal) rewrites yarn.lock resolved URLs so the frozen-lockfile install below stays consistent.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
+		echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
+	fi
+
 RUN yarn bootstrap && yarn cache clean
 
 FROM node:16-alpine3.14 AS development

--- a/.deploy/carrier-mobile-ionic/Dockerfile
+++ b/.deploy/carrier-mobile-ionic/Dockerfile
@@ -64,6 +64,16 @@ COPY --chown=node:node .snyk ./.snyk
 COPY --chown=node:node packages/common/package.json ./packages/common/package.json
 COPY --chown=node:node packages/common-angular/package.json ./packages/common-angular/package.json
 
+# Prefer the internal Verdaccio cache when VERDACCIO_REGISTRY is set (anonymous, backward-compatible);
+# empty (e.g. a fork) falls back to public npm. Writes the registry to .npmrc + .yarnrc and best-effort
+# (non-fatal) rewrites yarn.lock resolved URLs so the frozen-lockfile install below stays consistent.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
+		echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
+	fi
+
 RUN yarn bootstrap && yarn cache clean
 
 FROM node:16-alpine3.14 AS development

--- a/.deploy/merchant-tablet-ionic/Dockerfile
+++ b/.deploy/merchant-tablet-ionic/Dockerfile
@@ -64,6 +64,16 @@ COPY --chown=node:node .snyk ./.snyk
 COPY --chown=node:node packages/common/package.json ./packages/common/package.json
 COPY --chown=node:node packages/common-angular/package.json ./packages/common-angular/package.json
 
+# Prefer the internal Verdaccio cache when VERDACCIO_REGISTRY is set (anonymous, backward-compatible);
+# empty (e.g. a fork) falls back to public npm. Writes the registry to .npmrc + .yarnrc and best-effort
+# (non-fatal) rewrites yarn.lock resolved URLs so the frozen-lockfile install below stays consistent.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
+		echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
+	fi
+
 RUN yarn bootstrap && yarn cache clean
 
 FROM node:16-alpine3.14 AS development

--- a/.deploy/shop-mobile-ionic/Dockerfile
+++ b/.deploy/shop-mobile-ionic/Dockerfile
@@ -64,6 +64,16 @@ COPY --chown=node:node .snyk ./.snyk
 COPY --chown=node:node packages/common/package.json ./packages/common/package.json
 COPY --chown=node:node packages/common-angular/package.json ./packages/common-angular/package.json
 
+# Prefer the internal Verdaccio cache when VERDACCIO_REGISTRY is set (anonymous, backward-compatible);
+# empty (e.g. a fork) falls back to public npm. Writes the registry to .npmrc + .yarnrc and best-effort
+# (non-fatal) rewrites yarn.lock resolved URLs so the frozen-lockfile install below stays consistent.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
+		echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
+	fi
+
 RUN yarn bootstrap && yarn cache clean
 
 FROM node:16-alpine3.14 AS development

--- a/.deploy/shop-web-angular/Dockerfile
+++ b/.deploy/shop-web-angular/Dockerfile
@@ -58,6 +58,16 @@ COPY --chown=node:node .snyk ./.snyk
 COPY --chown=node:node packages/common/package.json ./packages/common/package.json
 COPY --chown=node:node packages/common-angular/package.json ./packages/common-angular/package.json
 
+# Prefer the internal Verdaccio cache when VERDACCIO_REGISTRY is set (anonymous, backward-compatible);
+# empty (e.g. a fork) falls back to public npm. Writes the registry to .npmrc + .yarnrc and best-effort
+# (non-fatal) rewrites yarn.lock resolved URLs so the frozen-lockfile install below stays consistent.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+		echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
+		echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
+		{ sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
+	fi
+
 RUN yarn bootstrap && yarn cache clean
 
 FROM node:16-alpine3.14 AS development

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -44,6 +44,8 @@ jobs:
                   context: .
                   file: ./.deploy/api/Dockerfile
                   load: true
+                  build-args: |
+                      VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
                   tags: |
                       ghcr.io/ever-co/ever-api:latest
                       everco/ever-api:latest
@@ -97,6 +99,8 @@ jobs:
                   context: .
                   file: ./.deploy/admin-web-angular/Dockerfile
                   load: true
+                  build-args: |
+                      VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
                   tags: |
                       ghcr.io/ever-co/ever-admin-angular:latest
                       everco/ever-admin-angular:latest
@@ -150,6 +154,8 @@ jobs:
                   context: .
                   file: ./.deploy/carrier-mobile-ionic/Dockerfile
                   load: true
+                  build-args: |
+                      VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
                   tags: |
                       ghcr.io/ever-co/ever-carrier-ionic:latest
                       everco/ever-carrier-ionic:latest
@@ -203,6 +209,8 @@ jobs:
                   context: .
                   file: ./.deploy/merchant-tablet-ionic/Dockerfile
                   load: true
+                  build-args: |
+                      VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
                   tags: |
                       ghcr.io/ever-co/ever-merchant-ionic:latest
                       everco/ever-merchant-ionic:latest
@@ -256,6 +264,8 @@ jobs:
                   context: .
                   file: ./.deploy/shop-mobile-ionic/Dockerfile
                   load: true
+                  build-args: |
+                      VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
                   tags: |
                       ghcr.io/ever-co/ever-shop-ionic:latest
                       everco/ever-shop-ionic:latest
@@ -309,6 +319,8 @@ jobs:
                   context: .
                   file: ./.deploy/shop-web-angular/Dockerfile
                   load: true
+                  build-args: |
+                      VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
                   tags: |
                       ghcr.io/ever-co/ever-shop-angular:latest
                       everco/ever-shop-angular:latest


### PR DESCRIPTION
## What

Route the in-cluster Docker builds' npm/yarn dependency install through our **internal Verdaccio cache** (reached via its VIP) instead of hitting public npm directly — mirroring the already-merged `ever-co/ever-teams` pattern, adapted to this repo's Lerna/Yarn-workspace layout.

## How

**All 6 `.deploy/*/Dockerfile`** (`api`, `admin-web-angular`, `carrier-mobile-ionic`, `merchant-tablet-ionic`, `shop-mobile-ionic`, `shop-web-angular`) — in the `dependencies` stage, immediately **before** `RUN yarn bootstrap && yarn cache clean` (which runs `yarn install --frozen-lockfile`):

```dockerfile
ARG VERDACCIO_REGISTRY=""
RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
        echo "registry=${VERDACCIO_REGISTRY}" >> /srv/ever/.npmrc && \
        echo "registry \"${VERDACCIO_REGISTRY}\"" >> /srv/ever/.yarnrc && \
        { sed -i "s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g; s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g" /srv/ever/yarn.lock 2>/dev/null || true; }; \
    fi
```

The `yarn.lock` rewrite matches the resolved URLs to the internal registry so `--frozen-lockfile` stays consistent; it is **non-fatal** (`|| true`), so a path/host mismatch degrades to public downloads rather than breaking the build.

**`.github/workflows/docker-build-publish.yml`** — each `docker/build-push-action` step now passes:

```yaml
build-args: |
    VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
```

This workflow already runs on our ARC runner (`${{ vars.RUNNER_LINUX_X64_4 }}`), which is the only runner that can reach the internal VIP. It is the single, non-env-split build workflow for the repo.

## Safety

- **Backward-compatible:** when the `VERDACCIO_REGISTRY` repo variable is unset, the build-arg is empty, the `if` block is skipped, and installs resolve from public npm exactly as today.
- **Fork-safe:** forks without the org variable get an empty value → public npm. No secrets required (the internal cache is accessed anonymously). The VIP is **never hardcoded** — always `${{ vars.VERDACCIO_REGISTRY }}`.
- **No prod change:** only the dependency *source* is redirected to a caching proxy of public npm; nothing about the built artifacts changes.

Do **not** merge without owner review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route dev and stage Docker builds to install `npm`/`yarn` deps via the internal Verdaccio VIP instead of public registries. Controlled by the `VERDACCIO_REGISTRY` build arg; empty falls back to public.

- **Refactors**
  - In all six `.deploy/*/Dockerfile` dependency stages, add `VERDACCIO_REGISTRY` and, when set, write it to `.npmrc` and `.yarnrc`, plus best-effort `yarn.lock` URL rewrites to keep `--frozen-lockfile` consistent.
  - Update `.github/workflows/docker-build-publish.yml` to pass `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` to each `docker/build-push-action` step (runs on the ARC runner that can reach the VIP).
  - Safe defaults: empty var uses public npm; anonymous access; no change to built artifacts.

<sup>Written for commit 2cb9580fc73ed759a60c87fc6ba5cc126797e99b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-demand/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

