### PR TITLE
ci: migrate runners to self-hosted ARC (develop)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Migrate non-self-hosted runner labels to the self-hosted ARC fleet on `develop`.

- `codeql-analysis.yml`: CodeQL `analyze` job `ubuntu-latest` -> `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (smallest per CodeQL policy).

The docker-build, deploy-do and harvest workflows already reference `vars.RUNNER_LINUX_X64_*` and were left untouched. arm/macos/windows/self-hosted labels and DO_ENABLED gates untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate the CodeQL analyze job to the self-hosted ARC pool by changing `runs-on` from `ubuntu-latest` to `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}`. This targets the smallest Linux x64 pool per policy and keeps a hosted fallback.

<sup>Written for commit e87b81ce16eb9424078a33c0852f02975c3a1fb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-demand/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

