### PR TITLE
ci: migrate runners to self-hosted ARC (stage)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy-do.yml
+++ b/.github/workflows/deploy-do.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
     deploy-dev:
-        runs-on: ubuntu-22.04
+        runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
         environment: dev
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     ever-api:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -60,7 +60,7 @@ jobs:
                   docker push everco/ever-api:latest
 
     ever-admin-angular:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -110,7 +110,7 @@ jobs:
                   docker push everco/ever-admin-angular:latest
 
     ever-carrier-ionic:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -160,7 +160,7 @@ jobs:
                   docker push everco/ever-carrier-ionic:latest
 
     ever-merchant-ionic:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -210,7 +210,7 @@ jobs:
                   docker push everco/ever-merchant-ionic:latest
 
     ever-shop-ionic:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
@@ -260,7 +260,7 @@ jobs:
                   docker push everco/ever-shop-ionic:latest
 
     ever-shop-angular:
-        runs-on: ubuntu-latest
+        runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7


### PR DESCRIPTION
Migrate non-self-hosted runner labels to the self-hosted ARC fleet on `stage`.

- `codeql-analysis.yml`: CodeQL analyze `ubuntu-latest` -> `RUNNER_LINUX_X64_4` (smallest per CodeQL policy)
- `deploy-do.yml`: `deploy-dev` (light) `ubuntu-22.04` -> `RUNNER_LINUX_X64_4`
- `docker-build-publish.yml`: 6 image-build jobs (heavy) `ubuntu-latest` -> `RUNNER_LINUX_X64_8`

All keep an `|| 'ubuntu-latest'` fallback. arm/macos/windows/self-hosted labels and DO_ENABLED gates untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate stage CI workflows to self-hosted ARC Linux x64 runners for more predictable capacity, with an `ubuntu-latest` fallback. Uses `RUNNER_LINUX_X64_4` for lighter jobs and `RUNNER_LINUX_X64_8` for heavy Docker builds.

- **Migration**
  - `codeql-analysis.yml` and `deploy-do.yml` -> `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}`
  - `docker-build-publish.yml` (6 image build jobs) -> `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}`
  - ARM/macOS/Windows labels and `DO_ENABLED` gates unchanged

<sup>Written for commit a829b420563f2358c25f1600921643bb53a5092a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-demand/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

