### PR TITLE
ci: gate legacy DigitalOcean deploy behind DO_ENABLED (fails on self-hosted ARC)

### DIFF
--- a/.github/workflows/deploy-do.yml
+++ b/.github/workflows/deploy-do.yml
@@ -17,6 +17,7 @@ on:
 jobs:
     deploy-dev:
         runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+        if: ${{ vars.DO_ENABLED == 'true' }}
 
         environment: dev
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -29,11 +29,13 @@ jobs:
                   username: ${{ github.repository_owner }}
                   password: ${{ secrets.GH_TOKEN }}
             - name: Install doctl
+              if: ${{ vars.DO_ENABLED == 'true' }}
               uses: digitalocean/action-doctl@v2
               with:
                   token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
             - name: Log in to DigitalOcean Container Registry with short-lived credentials
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: doctl registry login --expiry-seconds 3600
 
             - name: Build
@@ -48,6 +50,7 @@ jobs:
                       registry.digitalocean.com/ever/ever-api:latest
 
             - name: Push to DigitalOcean Registry
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: |
                   docker push registry.digitalocean.com/ever/ever-api:latest
 
@@ -80,10 +83,12 @@ jobs:
                   username: ${{ github.repository_owner }}
                   password: ${{ secrets.GH_TOKEN }}
             - name: Install doctl
+              if: ${{ vars.DO_ENABLED == 'true' }}
               uses: digitalocean/action-doctl@v2
               with:
                   token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
             - name: Log in to DigitalOcean Container Registry with short-lived credentials
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: doctl registry login --expiry-seconds 3600
 
             - name: Build
@@ -98,6 +103,7 @@ jobs:
                       registry.digitalocean.com/ever/ever-admin-angular:latest
 
             - name: Push to DigitalOcean Registry
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: |
                   docker push registry.digitalocean.com/ever/ever-admin-angular:latest
 
@@ -130,10 +136,12 @@ jobs:
                   username: ${{ github.repository_owner }}
                   password: ${{ secrets.GH_TOKEN }}
             - name: Install doctl
+              if: ${{ vars.DO_ENABLED == 'true' }}
               uses: digitalocean/action-doctl@v2
               with:
                   token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
             - name: Log in to DigitalOcean Container Registry with short-lived credentials
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: doctl registry login --expiry-seconds 3600
 
             - name: Build
@@ -148,6 +156,7 @@ jobs:
                       registry.digitalocean.com/ever/ever-carrier-ionic:latest
 
             - name: Push to DigitalOcean Registry
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: |
                   docker push registry.digitalocean.com/ever/ever-carrier-ionic:latest
 
@@ -180,10 +189,12 @@ jobs:
                   username: ${{ github.repository_owner }}
                   password: ${{ secrets.GH_TOKEN }}
             - name: Install doctl
+              if: ${{ vars.DO_ENABLED == 'true' }}
               uses: digitalocean/action-doctl@v2
               with:
                   token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
             - name: Log in to DigitalOcean Container Registry with short-lived credentials
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: doctl registry login --expiry-seconds 3600
 
             - name: Build
@@ -198,6 +209,7 @@ jobs:
                       registry.digitalocean.com/ever/ever-merchant-ionic:latest
 
             - name: Push to DigitalOcean Registry
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: |
                   docker push registry.digitalocean.com/ever/ever-merchant-ionic:latest
 
@@ -230,10 +242,12 @@ jobs:
                   username: ${{ github.repository_owner }}
                   password: ${{ secrets.GH_TOKEN }}
             - name: Install doctl
+              if: ${{ vars.DO_ENABLED == 'true' }}
               uses: digitalocean/action-doctl@v2
               with:
                   token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
             - name: Log in to DigitalOcean Container Registry with short-lived credentials
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: doctl registry login --expiry-seconds 3600
 
             - name: Build
@@ -248,6 +262,7 @@ jobs:
                       registry.digitalocean.com/ever/ever-shop-ionic:latest
 
             - name: Push to DigitalOcean Registry
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: |
                   docker push registry.digitalocean.com/ever/ever-shop-ionic:latest
 
@@ -280,10 +295,12 @@ jobs:
                   username: ${{ github.repository_owner }}
                   password: ${{ secrets.GH_TOKEN }}
             - name: Install doctl
+              if: ${{ vars.DO_ENABLED == 'true' }}
               uses: digitalocean/action-doctl@v2
               with:
                   token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
             - name: Log in to DigitalOcean Container Registry with short-lived credentials
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: doctl registry login --expiry-seconds 3600
 
             - name: Build
@@ -298,6 +315,7 @@ jobs:
                       registry.digitalocean.com/ever/ever-shop-angular:latest
 
             - name: Push to DigitalOcean Registry
+              if: ${{ vars.DO_ENABLED == 'true' }}
               run: |
                   docker push registry.digitalocean.com/ever/ever-shop-angular:latest
 


### PR DESCRIPTION
DigitalOcean is retired (`vars.DO_ENABLED` is unset). On self-hosted ARC these DO jobs/steps currently FAIL (`kubectl: command not found` / DO 403).

This gates them behind `if: ${{ vars.DO_ENABLED == 'true' }}` so they SKIP (green) instead of failing — mirroring the exact gating already present on the `develop` branch:

- `deploy-do.yml`: job-level gate on `deploy-dev`.
- `docker-build-publish.yml`: step-level gates on the 3 DO steps per job (Install doctl, DO registry login, Push to DigitalOcean Registry) — build/GHCR/Docker Hub steps keep running.

no-removal rule: gated, not deleted. Additive and reversible (set `DO_ENABLED=true` to re-enable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate legacy DigitalOcean deploys behind `vars.DO_ENABLED` so CI skips them instead of failing on self-hosted ARC, while GHCR/Docker Hub builds still run. Mirrors the gating on `develop` and is reversible.

- **Bug Fixes**
  - Job-level gate in `.github/workflows/deploy-do.yml` for `deploy-dev`.
  - Step-level gates in `.github/workflows/docker-build-publish.yml` for `Install doctl`, DO registry login, and push to DO registry.
  - Set `DO_ENABLED=true` to re-enable DigitalOcean steps.

<sup>Written for commit 3d8c5e102f239018c44ad6e9b1fccd5546ecadb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ever-co/ever-demand/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

